### PR TITLE
Add node.js example for retrieving metions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ You can contribute to [Microsoft Teams developer documentation](https://msdn.mic
 
 >**Note:** We're only taking documentation contributions from authors within Microsoft presently. We will open the repository for the Microsoft Teams content to non-Microsoft contributors soon.
 
-##Before we can accept your pull request
+## Before we can accept your pull request
 
-###Minor corrections
+### Minor corrections
 
 Minor corrections or clarifications you submit for documentation and code examples in this repository do not require a Contribution License Agreement (CLA). Submissions are taken in the form of pull requests. We will do our best to review pull requests within ten business days.
 
-###Larger submissions
+### Larger submissions
 
 If you submit new or significant changes to documentation and code examples, you need to send a signed Contribution License Agreement (CLA) before we can accept your pull request if you are in one of these groups:
 
@@ -42,6 +42,6 @@ Once we receive and process your CLA, we will do our best to review your pull re
 For more guidance on contributing to Office developer documentation, see [CONTRIBUTING.md](https://github.com/OfficeDev/microsoft-teams-docs/blob/master/CONTRIBUTING.md) in this repo. 
 
 
-##Copyright
+## Copyright
 Copyright (c) 2016 Microsoft Corporation. All rights reserved.
 

--- a/teams/botsconversation.md
+++ b/teams/botsconversation.md
@@ -23,7 +23,7 @@ Of note:
 * `from.id` - This is a unique and encrypted id for that user for your bot, and is suitable as a key should your app wish to store user data.  Note, though, that this is unique for your bot and cannot be directly used outside your bot instance in any meaningful way to identify that user.
 
 ### Replying to message
-In order to reply to an existing message, you simply need to call the `ReplyToActivity()` in [C#](https://docs.botframework.com/en-us/csharp/builder/sdkreference/routing.html#replying) or 'session.send' in [Node.JS](https://docs.botframework.com/en-us/node/builder/chat/session/#sending-messages).  The BotFramework SDK handles all the details.
+In order to reply to an existing message, you simply need to call the [`ReplyToActivity()` in C#](https://docs.botframework.com/en-us/csharp/builder/sdkreference/routing.html#replying) or [`session.send` in Node.JS](https://docs.botframework.com/en-us/node/builder/chat/session/#sending-messages).  The BotFramework SDK handles all the details.
 
 If you choose to use the REST API, you can also call the [/conversations/{conversationId}/activities/{activityId}`](https://docs.botframework.com/en-us/restapi/connector/#/Conversations) endpoint. Please note:  if you are constructing the outgoing payload yourself, always use the `serviceUrl` received in the inbound messages as your outbound `serviceUrl`.
 
@@ -76,6 +76,7 @@ You can retrieve all mentions in the message by calling the `GetMentions()` func
 
 Note that bots in a channel only respond if @mentioned and therefore the body of the text message will always include the @Bot name.  Ensure your message parsing excludes that.  For example:
 
+#### C# ####
 ```c#
 Mention[] m = sourceMessage.GetMentions();
 var messageText = sourceMessage.Text;
@@ -85,9 +86,26 @@ for (int i = 0;i < m.Length;i++)
     if (m[i].Mentioned.Id == sourceMessage.Recipient.Id)
     {
         //Bot is in the @mention list.  
-        //The below example will strip the bot name out of the message, so you can parse it as if it wasn't included.  Note that the Text object will contain the full bot name, if applicable.
+        //The below example will strip the bot name out of the message, so you can parse it as if it wasn't included.
+        //Note that the Text object will contain the full bot name, if applicable.
         if (m[i].Text != null)
             messageText = messageText.Replace(m[i].Text, "");
+    }
+}
+```
+
+#### Node ####
+```javascript
+function(session) {
+    var entities = session.message.entities;
+    var i;
+    for (i = 0; i < entities.length; i++) {
+        var entity = entities[i];
+        if (entity.type === 'mention' && entity.mentioned.name === 'MyTestBot') {
+            // The bot is mentioned.
+            // Do some thing here
+            session.send("What's up?");
+        }
     }
 }
 ```


### PR DESCRIPTION
Added node.js example for retrieving metions. For other examples on the same page (create conversation, fetch team roster), I don't think  bot framework's Node.JS API is usable.