### PR TITLE
Many changes (see description)

### DIFF
--- a/teams/schema.md
+++ b/teams/schema.md
@@ -154,22 +154,22 @@ This is a unique identifier for this app in reverse domain notation. E.g: com.ex
 
 The developer element specifies information about your company.  For Store-submitted apps, these values must match the information in your Store entry.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
-|`name`|String||✔||The display name for the developer.|
-|`websiteUrl`|String||✔|The url to the developer's website.  This link should take users to your company or product-specific landing page.|
-|`privacyUrl`|String||✔|The url to the developer's privacy policy.|
-|`termsOfUseUrl`|String||✔|The url to the developer's terms of use.|
+|`name`|String|32|✔|The display name for the developer.|
+|`websiteUrl`|String|2048|✔|The URL to the developer's website.  This link should take users to your company or product-specific landing page.|
+|`privacyUrl`|String|2048|✔|The URL to the developer's privacy policy.|
+|`termsOfUseUrl`|String|2048|✔|The URL to the developer's terms of use.|
 
 
 ## name
 
 This is the name of your app experience, displayed to users in the Teams experience.  For Store-submitted apps, these values must match the information in your Store entry.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
 |`short`|String|30|✔|The short display name for the app.|
-|`full`|String|100|✘|The full name of the app, used if the full app name exceeds 30 characters.|
+|`full`|String|100||The full name of the app, used if the full app name exceeds 30 characters.|
 
 
 ## description
@@ -178,7 +178,7 @@ These values describe your app to users.  For Store-submitted apps, these values
 
 Please note that you should make your description accurately describes your experience, and provided the right information to help potential new customers understand what your experience does.  You should also note, in the full description, if an external account is required for use.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
 |`short`|String|80|✔|A short description of your app experience, used when space is limited.|
 |`full`|String|4000|✔|The full description of your app.|
@@ -189,10 +189,10 @@ Please note that you should make your description accurately describes your expe
 
 Icons are used within the Teams app, and must be included as part of the sideload package.  See [here](createpackage.md#icons) for more information.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
-|`outline`|String||✔|A relative file path to a transparent 20x20 PNG outline icon.|
-|`color`|String||✔|A relative file path to a full color 96x96 PNG icon.|
+|`outline`|String|2048|✔|A relative file path to a transparent 20x20 PNG outline icon.|
+|`color`|String|2048|✔|A relative file path to a full color 96x96 PNG icon.|
 
 ## accentColor (string, required)
 
@@ -206,11 +206,11 @@ The configurableTabs block is used in cases where your app experience has a team
 
 The object is an array with all elements of the type `object`.  This block is only required for solutions that provide a configurable channel Tab solution.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
-|`configurationUrl`|String||✔|The url to use when configuring the tab.|
+|`configurationUrl`|String|2048|✔|The URL to use when configuring the tab.|
 |`canUpdateConfiguration`|Boolean|||A value indicating whether an instance of the tab's configuration can be updated by the user after creation.  Default: `true`|
-|`scopes`|Array of enum||✔|Currently, configurable tabs only support the `team` scope, which means it can only be provisioned to a channel.|
+|`scopes`|Array of enum|1|✔|Currently, configurable tabs only support the `team` scope, which means it can only be provisioned to a channel.|
 
 
 ## staticTabs
@@ -219,27 +219,27 @@ The staticTabs block defines a set of tabs that may be "pinned" by default, with
 
 The object is an array (max: 16) with all elements of the type `object`.  This block is only required for solutions that provide a static tab solution.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
 |`entityId`|String|64|✔|A unique identifier for the entity which the tab displays.|
 |`name`|String|128|✔|The display name of the tab in the channel interface.|
-|`contentUrl`|String||✔|The url which points to the entity UI to be displayed in the Teams canvas.  Must be HTTPS.|
-|`websiteUrl`|String|||The url to point at if a user opts to view in a browser.|
-|`scopes`|Array of enum||✔|Currently, static tabs only support the `personal` scope, which means it can only be provisioned in as part of the personal experience.|
+|`contentUrl`|String|2048|✔|The URL which points to the entity UI to be displayed in the Teams canvas.  Must be HTTPS.|
+|`websiteUrl`|String|2048||The URL to point at if a user opts to view in a browser.|
+|`scopes`|Array of enum|1|✔|Currently, static tabs only support the `personal` scope, which means it can only be provisioned in as part of the personal experience.|
 
 
 ## bots
 
 The bots block defines a bot solution, along with additional optional information like default command properties.
 
-The object is an array (max: 1) with all elements of the type `object`.  This block is only required for solutions that provide a Bot experience.
+The object is an array (max: 1 -- currently only one bot is allowed per app) with all elements of the type `object`.  This block is only required for solutions that provide a Bot experience.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
-|`botId`|String|64|✔|A unique identifier for the bot that matches its ID in the Bot Framework.|
+|`botId`|String|64 characters|✔|A unique identifier for the bot that matches its ID in the Bot Framework.|
 |`needsChannelSelector`|Boolean|||This value describes whether or not the bot utilizes a user hint to add the bot to a specific channel. Default: `false`|
 |`isNotificationOnly`|Boolean|||A flag which indicates whether a bot is a one-way notification only bot, as opposed to a conversational bot. Default: `false`|
-|`scopes`|Array of enum||✔|Specifies whether the bot offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). These options are non-exclusive.|
+|`scopes`|Array of enum|2|✔|Specifies whether the bot offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). These options are non-exclusive.|
 
 ### bots: commandLists
 
@@ -247,10 +247,10 @@ The object is an array (max: 1) with all elements of the type `object`.  This bl
 
 You can provide an optional list of commands that your bot can recommend to users.  The object is an array (max: 2) with all elements of type `object` - you must define a separate command list for each scope that your bot supports.  See [here](botmenu.md) for more information.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
-|`items.properties`|array of enum||✔|Specifies the scope for which the command list if valid.|
-|`items.commands`|array of objects|max 10|✔|An array of commands the bot supports:<br>`title`: the bot command name (string, 32)<br>`description`: a simple description or example of the command syntax and its argumenst (string, 128)|
+|`items.properties`|array of enum|2|✔|Specifies the scope for which the command list if valid.|
+|`items.commands`|array of objects|10|✔|An array of commands the bot supports:<br>`title`: the bot command name (string, 32)<br>`description`: a simple description or example of the command syntax and its argumenst (string, 128)|
 
 
 ## connectors
@@ -261,10 +261,10 @@ The connectors block defines an Office365 connector for the app.
 
 The object is an array (max:1) with all elements of type `object`.  This block is only required for solutions that provide a connector.
      
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
 |`connectorId`|String|64|✔|A unique identifier for the connector that matches its ID in the Connectors Developer Portal.|
-|`scopes`|Array of enum||✔|Specifies whether the connector offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). These options are non-exclusive.|
+|`scopes`|Array of enum|1|✔|Specifies whether the connector offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). Currently, only the `team` scope is supported.|
 
 ## composeExtensions
 
@@ -274,26 +274,27 @@ The composeExtension block defines a compose extension for the app.
 
 The object is an array (max:1) with all elements of type `object`.  This block is only required for solutions that provide a compose extension.
 
-|Name| Type| Size | Required | Description|
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
 |`botId`|String|64|✔|A unique identifier for the bot which is backing the compose extension that matches its ID in the Bot Framework.|
-|`scopes`|Array of enum||✔|Specifies whether the bot offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). These options are non-exclusive.|
+|`scopes`|Array of enum|2|✔|Specifies whether the bot offers an experience in the context of a channel in a `team`, or an experience scoped to an individual user alone (`personal`). These options are non-exclusive.|
 |`commands`|Array of object|1|✔|Array of commands the compose extension supports|
 
 ### composeExtensions.commands
 Your compose extension should declare one or more commands. Each command appears in Microsoft Teams as a potential interaction from the UI-based entry point.
 
 Each command item is an object with the following structure:
-|Name| Type| Size | Required | Description|
+
+|Name| Type| Maximum Size | Required | Description|
 |---|---|---|---|---|
-|`id`|String|64|✔|A GUID of the command|✔|
+|`id`|String|64|✔|The ID for the command|
 |`title`|String|32|✔|The user friendly command name|
 |`description`|String|128||The description that appears to users to indicate the purpose of this command|
 |`initialRun`|Boolean|||A boolean value that indicates if the command should be run initially with no parameters.  Default: `false`|
 |`parameters`|Array of Objects|5|✔|The list of parameters the command takes.  Min:1, Max: 5|
 |`parameter.name`|String|64|✔|The name of the parameter as it appears in the client.  This is included in the user request.|
 |`parameter.title`|String|32|✔|User-friendly title for the parameter.|
-|`parameter.description`|String|128||User-friendly string that describes this parameter’s purposes.|
+|`parameter.description`|String|128||User-friendly string that describes this parameter’s purpose.|
 
 
 ## permissions


### PR DESCRIPTION
"Size" -> "Maximum Size" column heading
"url" -> "URL"
Added max size for many of the table values
For non-required values, we left the table cell blank except in one place, made that more consistent
composeExtensions.commands table was completely messed up, fixed it
Fixed a few other table formatting bugs
Added a clarification re: why bots per app is max 1
Compose extension command IDs are not GUIDs, just unique strings